### PR TITLE
fix: dynamic links applying href and as props

### DIFF
--- a/packages/link/__fixtures__/link.js
+++ b/packages/link/__fixtures__/link.js
@@ -5,11 +5,9 @@ const props = {
   href: 'https://www.newfrontdoor.org'
 };
 
-export default {
+const fixtures = {
   external: <Link {...props}>NEw FRont DOor</Link>,
-  internal: (
-    <Link isInternal href="sermons">
-      Link to /sermons
-    </Link>
-  )
+  internal: <Link href="sermons">Link to /sermons</Link>
 };
+
+export default fixtures;

--- a/packages/link/__tests__/link.test.js
+++ b/packages/link/__tests__/link.test.js
@@ -4,7 +4,9 @@ import {render} from '@testing-library/react';
 import {Link} from '../src';
 
 function renderWithContext(children) {
-  const components = {a: props => <fake-link role="link" {...props} />};
+  const components = {
+    a: (props) => <fake-link role="link" {...props} />
+  };
   return render(
     <ThemeProvider components={components}>{children}</ThemeProvider>
   );
@@ -16,6 +18,7 @@ test('href is applied to the link', () => {
   const link = getByRole('link');
 
   expect(link).toHaveAttribute('href', href);
+  expect(link).not.toHaveAttribute('as');
 });
 
 test('children is applied to the link', () => {
@@ -25,6 +28,7 @@ test('children is applied to the link', () => {
   const link = getByRole('link');
 
   expect(link).toHaveTextContent('Welcome');
+  expect(link).not.toHaveAttribute('as');
 });
 
 test('isTargetBlank adds target and rel attributes to the link', () => {
@@ -35,20 +39,20 @@ test('isTargetBlank adds target and rel attributes to the link', () => {
 
   expect(link).toHaveAttribute('target', '_blank');
   expect(link).toHaveAttribute('rel', 'noreferrer noopener');
+  expect(link).not.toHaveAttribute('as');
 });
 
 test('it uses the Link component from ThemeProvider to render internal links', () => {
-  const {getByRole} = renderWithContext(
-    <Link isInternal href="/example/page" />
-  );
+  const {getByRole} = renderWithContext(<Link href="/example/page" />);
   const link = getByRole('link');
 
   expect(link).toHaveAttribute('href', '/example/page');
+  expect(link).not.toHaveAttribute('as');
 });
 
 test('href and as props are applied to internal links', () => {
   const {getByRole} = renderWithContext(
-    <Link isInternal href="/example/[slug]" as="/example/id" />
+    <Link href="/example/[slug]" as="/example/id" />
   );
   const link = getByRole('link');
 
@@ -57,9 +61,10 @@ test('href and as props are applied to internal links', () => {
 });
 
 test('does not render api urls as internal links', () => {
-  const {getByRole} = renderWithContext(<Link isInternal href="/api/user/1" />);
+  const {getByRole} = renderWithContext(<Link href="/api/user/1" />);
   const link = getByRole('link');
 
   expect(link).toHaveAttribute('href', '/api/user/1');
   expect(link).not.toHaveAttribute('isInternal');
+  expect(link).not.toHaveAttribute('as');
 });

--- a/packages/link/__tests__/navlink.test.js
+++ b/packages/link/__tests__/navlink.test.js
@@ -1,21 +1,32 @@
 import React from 'react';
+import {ThemeProvider} from 'theme-ui';
 import {matchers} from 'jest-emotion';
 import {render} from '@testing-library/react';
 import {Navlink} from '../src';
 
 expect.extend(matchers);
 
+function renderWithContext(children) {
+  const components = {
+    a: (props) => <fake-link role="link" {...props} />
+  };
+  return render(
+    <ThemeProvider components={components}>{children}</ThemeProvider>
+  );
+}
+
 test('href is applied to the link', () => {
   const href = 'https://www.example.com';
-  const {getByRole} = render(<Navlink href={href}>Nav 1</Navlink>);
+  const {getByRole} = renderWithContext(<Navlink href={href}>Nav 1</Navlink>);
   const link = getByRole('link');
 
   expect(link).toHaveAttribute('href', href);
   expect(link).not.toHaveStyleRule('color');
+  expect(link).not.toHaveAttribute('as');
 });
 
 test('active styles are applied when active', () => {
-  const {getByRole} = render(
+  const {getByRole} = renderWithContext(
     <Navlink active href="https://www.example.com">
       Nav 2
     </Navlink>
@@ -23,4 +34,17 @@ test('active styles are applied when active', () => {
   const link = getByRole('link');
 
   expect(link).toHaveStyleRule('color', 'active');
+  expect(link).not.toHaveAttribute('as');
+});
+
+test('href and as props are applied to Link', () => {
+  const {getByRole} = renderWithContext(
+    <Navlink active href="/foo/[bar]" as="/foo/123">
+      Nav 2
+    </Navlink>
+  );
+  const link = getByRole('link');
+
+  expect(link).toHaveAttribute('href', '/foo/[bar]');
+  expect(link).toHaveAttribute('as', '/foo/123');
 });

--- a/packages/link/src/link.js
+++ b/packages/link/src/link.js
@@ -5,14 +5,16 @@ import PropTypes from 'prop-types';
 
 // TODO: const regex = /^(?!www\.|(?:http|ftp)s?:\/\/|[A-Za-z]:\\|\/\/|api|\/api).*/;
 
-const Link = props => {
+const Link = (props) => {
   const components = useMDXComponents();
   const AppLink = components.a;
 
-  const {as, href, isInternal, isTargetBlank, ...rest} = props;
+  const {as, href, isTargetBlank, ...rest} = props;
   const isNotApi = href && !href.startsWith('/api/');
+  const startsWithSlash = href?.startsWith('/');
+  const useAppLink = startsWithSlash && isNotApi;
 
-  if (href && isInternal && isNotApi) {
+  if (useAppLink) {
     return (
       <AppLink as={as} href={href} {...rest}>
         <ThemeUiLink {...rest} />
@@ -31,15 +33,13 @@ const Link = props => {
 Link.propTypes = {
   as: PropTypes.string,
   variant: PropTypes.string,
-  href: PropTypes.string,
-  isInternal: PropTypes.bool,
+  href: PropTypes.string.isRequired,
   isTargetBlank: PropTypes.bool,
   hasNoAnchor: PropTypes.bool
 };
 
 Link.defaultProps = {
-  as: undefined,
-  href: undefined
+  as: undefined
 };
 
 export default Link;

--- a/packages/link/src/navlink.js
+++ b/packages/link/src/navlink.js
@@ -16,12 +16,14 @@ const Navlink = ({as, href, active, children}) => {
 };
 
 Navlink.propTypes = {
+  as: PropTypes.string,
   active: PropTypes.bool,
   href: PropTypes.string.isRequired,
   children: PropTypes.string.isRequired
 };
 
 Navlink.defaulProps = {
+  as: undefined,
   active: false
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1348,39 +1348,6 @@
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz#8eed982e2ee6f7f4e44c253e12962980791efd46"
   integrity sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==
 
-"@fortawesome/fontawesome-common-types@^0.2.30":
-  version "0.2.30"
-  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.30.tgz#2f1cc5b46bd76723be41d0013a8450c9ba92b777"
-  integrity sha512-TsRwpTuKwFNiPhk1UfKgw7zNPeV5RhNp2Uw3pws+9gDAkPGKrtjR1y2lI3SYn7+YzyfuNknflpBA1LRKjt7hMg==
-
-"@fortawesome/fontawesome-svg-core@^1.2.30":
-  version "1.2.30"
-  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.30.tgz#f56dc6791861fe5d1af04fb8abddb94658c576db"
-  integrity sha512-E3sAXATKCSVnT17HYmZjjbcmwihrNOCkoU7dVMlasrcwiJAHxSKeZ+4WN5O+ElgO/FaYgJmASl8p9N7/B/RttA==
-  dependencies:
-    "@fortawesome/fontawesome-common-types" "^0.2.30"
-
-"@fortawesome/free-brands-svg-icons@^5.14.0":
-  version "5.14.0"
-  resolved "https://registry.yarnpkg.com/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-5.14.0.tgz#98555518ba41bdff82fbae2f4d1bc36cd3b1c043"
-  integrity sha512-WsqPFTvJFI7MYkcy0jeFE2zY+blC4OrnB9MJOcn1NxRXT/sSfEEhrI7CwzIkiYajLiVDBKWeErYOvpsMeodmCQ==
-  dependencies:
-    "@fortawesome/fontawesome-common-types" "^0.2.30"
-
-"@fortawesome/free-solid-svg-icons@^5.14.0":
-  version "5.14.0"
-  resolved "https://registry.yarnpkg.com/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.14.0.tgz#970453f5e8c4915ad57856c3a0252ac63f6fec18"
-  integrity sha512-M933RDM8cecaKMWDSk3FRYdnzWGW7kBBlGNGfvqLVwcwhUPNj9gcw+xZMrqBdRqxnSXdl3zWzTCNNGEtFUq67Q==
-  dependencies:
-    "@fortawesome/fontawesome-common-types" "^0.2.30"
-
-"@fortawesome/react-fontawesome@^0.1.11":
-  version "0.1.11"
-  resolved "https://registry.yarnpkg.com/@fortawesome/react-fontawesome/-/react-fontawesome-0.1.11.tgz#c1a95a2bdb6a18fa97b355a563832e248bf6ef4a"
-  integrity sha512-sClfojasRifQKI0OPqTy8Ln8iIhnxR/Pv/hukBhWnBz9kQRmqi6JSH3nghlhAY7SUeIIM7B5/D2G8WjX0iepVg==
-  dependencies:
-    prop-types "^15.7.2"
-
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz#fd3db1d59ecf7cf121e80650bb86712f9b55eced"
@@ -10328,7 +10295,7 @@ react-global-configuration@^1.3.0:
     object-assign "^4.1.1"
     serialize-javascript "^2.1.0"
 
-react-icons@^3.7.0:
+react-icons@^3.10.0, react-icons@^3.7.0:
   version "3.10.0"
   resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-3.10.0.tgz#6c217a2dde2e8fa8d293210023914b123f317297"
   integrity sha512-WsQ5n1JToG9VixWilSo1bHv842Cj5aZqTGiS3Ud47myF6aK7S/IUY2+dHcBdmkQcCFRuHsJ9OMUI0kTDfjyZXQ==


### PR DESCRIPTION
Removes the `isInternal` props, and checks `href` instead, to see if it's an absolute URL

https://developer.mozilla.org/en-US/docs/Learn/Common_questions/What_is_a_URL#Examples_of_absolute_URLs

Specifically..

> Implicit domain name
> `/en-US/docs/Learn`